### PR TITLE
Add aws.yaml file to deploy container to ECR through github actions

### DIFF
--- a/.github/workflows/aws.yaml
+++ b/.github/workflows/aws.yaml
@@ -1,0 +1,51 @@
+# This workflow will build and push a new container image to Amazon ECR
+
+on:
+  push:
+    branches:
+      - dataseed
+    paths:
+      - 'requirements.txt'
+      - 'packages.R'
+      - 'Dockerfile'
+
+name: Deploy to Amazon ECR
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY_NAME }}
+        # tag with the commit sha, ideally use git tags instead
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+    - name: Logout of Amazon ECR
+      if: always()
+      run: docker logout ${{ steps.login-ecr.outputs.registry }}


### PR DESCRIPTION
This changes add the ability to deploy a container in an ECR repository using Github Actions when changes occur on the `Dockerfile`, `packages.R` and `requirements.txt`.

To enable this deployment users need to setup an IAM user following the recommendations provided [here](https://github.com/aws-actions/amazon-ecr-login) and setup the following in the [GitHub Actions secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets):

- AWS_ACCESS_KEY_ID: individual user aws access key id.
- AWS_SECRET_ACCESS_KEY: individual user aws secret access key.
- ECR_REPOSITORY_NAME: name of the ECR repository (not ARN).

When this branch is merged to `master`, the `on` section of the file will need to be updated from:

```yaml
on:
  push:
    branches:
      - dataseed
```

to:

```yaml
on:
  push:
    branches:
      - master
```

Additional deployment jobs to ECR can be added following this template.