### PR TITLE
Move the installation of our local packages out of the docker container build

### DIFF
--- a/local_install.R
+++ b/local_install.R
@@ -1,0 +1,11 @@
+library(devtools)
+  
+initial.options <- commandArgs(trailingOnly = FALSE)
+file.arg.name <- "--file="
+script.name <- sub(file.arg.name, "", initial.options[grep(file.arg.name, initial.options)])
+pkg.dir <- paste0(dirname(script.name), "/R/pkgs/")
+
+install_local(paste0(pkg.dir, "covidcommon"), force=TRUE, upgrade="never")
+install_local(paste0(pkg.dir, "hospitalization"), force=TRUE, upgrade="never")
+install_local(paste0(pkg.dir, "importation_estimation"), force=TRUE, upgrade="never")
+install_local(paste0(pkg.dir, "report_generation"), force=TRUE, upgrade="never")

--- a/packages.R
+++ b/packages.R
@@ -28,9 +28,3 @@ install_version("tidycensus", version = "0.9.5")
 install_version("yaml", version = "2.2.1")
 install_version("optparse", version = "1.6.4")
 install_version("lubridate", version = "1.7.4")
-
-# Install the packages we developed ourselves
-install_local("R/pkgs/covidcommon")
-install_local("R/pkgs/hospitalization")
-install_local("R/pkgs/importation_estimation")
-install_local("R/pkgs/report_generation")


### PR DESCRIPTION
Putting them into a standalone, lightweight script called `local_install.R` that can be run when initializing a new container.