### PR TITLE
Some minimalist changes to the python code that I think should make the core loop faster

### DIFF
--- a/SEIR/seir.py
+++ b/SEIR/seir.py
@@ -2,7 +2,6 @@ import itertools
 import time
 import uuid
 
-from numba import jit
 import numpy as np
 import pandas as pd
 import scipy
@@ -79,8 +78,6 @@ def run_parallel(s, *, n_jobs=1):
 """)
 
 
-#@jit(float64[:,:,:](float64[:,:], float64[:], int64), nopython=True)
-@jit(nopython=True)
 def steps_SEIR_nb(p_vec, y0, uid, dt, t_inter, nnodes, popnodes, mobility,
                   dynfilter, importation):
     """

--- a/SEIR/seir.py
+++ b/SEIR/seir.py
@@ -109,22 +109,22 @@ def steps_SEIR_nb(p_vec, y0, uid, dt, t_inter, nnodes, popnodes, mobility,
             y[E] = y[E] + importation[int(t)]
         for ori in range(nnodes):
             for dest in range(nnodes):
-                for c in range(ncomp - 1):
-                    mv[c] = np.random.binomial(
-                        y[c, ori],
-                        1 - np.exp(-dt * mobility[ori, dest] / popnodes[ori]))
-                y[:-1, dest] += mv
-                y[:-1, ori] -= mv
+                if mobility[ori, dest] > 0.0:
+                    for c in range(ncomp - 1):
+                        mv[c] = np.random.binomial(
+                            y[c, ori],
+                            1 - np.exp(-dt * mobility[ori, dest] / popnodes[ori]))
+                    y[:-1, dest] += mv
+                    y[:-1, ori] -= mv
 
         p_expose = 1 - np.exp(-dt * p_vec[0][it] *
                               (y[I1] + y[I2] + y[I3]) / popnodes)  # vector
 
-        for i in range(nnodes):
-            exposeCases[i] = np.random.binomial(y[S][i], p_expose[i])
-            incidentCases[i] = np.random.binomial(y[E][i], p_infect)
-            incident2Cases[i] = np.random.binomial(y[I1][i], p_recover)
-            incident3Cases[i] = np.random.binomial(y[I2][i], p_recover)
-            recoveredCases[i] = np.random.binomial(y[I3][i], p_recover)
+        exposeCases = np.random.binomial(y[S], p_expose)
+        incidentCases = np.random.binomial(y[E], p_infect)
+        incident2Cases = np.random.binomial(y[I1], p_recover)
+        incident3Cases = np.random.binomial(y[I2], p_recover)
+        recoveredCases = np.random.binomial(y[I3], p_recover)
 
         y[S] += -exposeCases
         y[E] += exposeCases - incidentCases

--- a/SEIR/seir.py
+++ b/SEIR/seir.py
@@ -120,11 +120,12 @@ def steps_SEIR_nb(p_vec, y0, uid, dt, t_inter, nnodes, popnodes, mobility,
         p_expose = 1 - np.exp(-dt * p_vec[0][it] *
                               (y[I1] + y[I2] + y[I3]) / popnodes)  # vector
 
-        exposeCases = np.random.binomial(y[S], p_expose)
-        incidentCases = np.random.binomial(y[E], p_infect)
-        incident2Cases = np.random.binomial(y[I1], p_recover)
-        incident3Cases = np.random.binomial(y[I2], p_recover)
-        recoveredCases = np.random.binomial(y[I3], p_recover)
+        for i in range(nnodes):
+            exposeCases[i] = np.random.binomial(y[S][i], p_expose[i])
+            incidentCases[i] = np.random.binomial(y[E][i], p_infect)
+            incident2Cases[i] = np.random.binomial(y[I1][i], p_recover)
+            incident3Cases[i] = np.random.binomial(y[I2][i], p_recover)
+            recoveredCases[i] = np.random.binomial(y[I3][i], p_recover)
 
         y[S] += -exposeCases
         y[E] += exposeCases - incidentCases


### PR DESCRIPTION
1) Skip ori-dest pairs that don't have any travel between them in updating the y values.
2) Vectorize the calls to np.random.binomial and eliminate the loop over nnodes (this one seemed a bit iffier to me if the JIT is doing its thing, but the code seemed cleaner and more consistent w/the other vectorized bits of the loop.)

Was going to try this out later tonight against the minimalist config and see how it goes!