### PR TITLE
Jwills jit with sparse

### DIFF
--- a/SEIR/seir.py
+++ b/SEIR/seir.py
@@ -25,9 +25,11 @@ def onerun_SEIR(uid, s):
 
     seeding = setup.seeding_draw(s, uid)
 
+    mobility_ori, mobility_dest = s.mobility.row, s.mobility.col
+    mobility_prob = 1.0 - np.exp(-s.dt * s.mobility.data / s.popnodes[mobility_ori])
     states = steps_SEIR_nb(setup.parameters_quick_draw(s, npi),
-                           seeding, uid, s.dt, s.t_inter,
-                           s.nnodes, s.popnodes, s.mobility, s.dynfilter)
+                           seeding, uid, s.dt, s.t_inter, s.nnodes, s.popnodes,
+                           mobility_ori, mobility_dest, mobility_probs, s.dynfilter)
 
     # Tidyup data for  R, to save it:
     if s.write_csv:
@@ -80,10 +82,9 @@ def run_parallel(s, *, n_jobs=1):
 """)
 
 
-#@jit(float64[:,:,:](float64[:,:], float64[:], int64), nopython=True)
 @jit(nopython=True)
-def steps_SEIR_nb(p_vec, seeding, uid, dt, t_inter, nnodes, popnodes, mobility,
-                  dynfilter):
+def steps_SEIR_nb(p_vec, seeding, uid, dt, t_inter, nnodes, popnodes,
+                  mobility_ori, mobility_dest, mobility_probs, dynfilter):
     """
         Made to run just-in-time-compiled by numba, hence very descriptive and using loop,
         because loops are expanded by the compiler hence not a problem.
@@ -91,6 +92,7 @@ def steps_SEIR_nb(p_vec, seeding, uid, dt, t_inter, nnodes, popnodes, mobility,
     """
     #np.random.seed(uid)
     t = 0
+    mobility_len = len(mobility_ori)
 
     y = np.zeros((ncomp, nnodes))
     y[S, :] = popnodes
@@ -110,14 +112,14 @@ def steps_SEIR_nb(p_vec, seeding, uid, dt, t_inter, nnodes, popnodes, mobility,
         if (it % int(1 / dt) == 0):
             y[I1] = y[I1] + seeding[int(t)]
             y[cumI] = y[cumI] + seeding[int(t)]
-        for ori in range(nnodes):
-            for dest in range(nnodes):
-                for c in range(ncomp - 1):
-                    mv[c] = np.random.binomial(
-                        y[c, ori],
-                        1 - np.exp(-dt * mobility[ori, dest] / popnodes[ori]))
-                y[:-1, dest] += mv
-                y[:-1, ori] -= mv
+        for i in range(mobility_len):
+            ori = mobility_ori[i]
+            dest = mobility_dest[i]
+            prob = mobility_prob[i]
+            for c in range(ncomp - 1):
+                mv[c] = np.random.binomial(y[c, ori], prob)
+            y[:-1, dest] += mv
+            y[:-1, ori] -= mv
 
         p_expose = 1 - np.exp(-dt * p_vec[0][it] *
                               (y[I1] + y[I2] + y[I3]) / popnodes)  # vector

--- a/SEIR/setup.py
+++ b/SEIR/setup.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import datetime
 import os
+import scipy.sparse
 
 from .utils import config
 
@@ -15,7 +16,7 @@ class SpatialSetup:
         self.setup_name = setup_name
         self.folder = folder
         self.data = pd.read_csv(geodata_file, converters={nodenames_key: lambda x: str(x)})
-        self.mobility = np.loadtxt(mobility_file)
+        self.mobility = scipy.sparse.coo_matrix(np.loadtxt(mobility_file))
         self.popnodes = self.data[popnodes_key].to_numpy()
         self.nodenames = self.data[nodenames_key].tolist()
         self.nnodes = len(self.data)


### PR DESCRIPTION
Moving the mobility data to using a COO sparse matrix format and keeping JIT compatability in the core loop by passing the underlying numpy arrays as arguments to the `steps_SEIR_nb` function. On 32 cores w/1000 runs of the the `Lockdown_Uncontrolled` CA scenario, runtime went from 1050 seconds to 726 seconds, a 30% speed up.