### PR TITLE
Use a later version of git so I can re-use the docker container for CI on GH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN set -e \
       && apt-get -y install --no-install-recommends --no-install-suggests \
         gnupg2 gnupg1 ca-certificates software-properties-common \
       && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 \
-      && add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/'
+      && add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/' \
+      && add-apt-repository ppa:git-core/ppa
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
I'm planning on using the `hopkinsidd/covidscenariopipeline` container for running R and Python tests on PR/merge to master b/c it cuts down our setup times dramatically and ensures that our tests are running with the same setup as our production environment. GH's built-in `checkout` action needs at least `git` 2.18 to work correctly w/a container-based CI run, so I'm upgrading the version of git the container ships with from 2.17.1 to the latest stable version, which is 2.26.0.
