### PR TITLE
Remove this invalid config checking pattern from our scripts

### DIFF
--- a/R/scripts/create_filter.R
+++ b/R/scripts/create_filter.R
@@ -11,7 +11,7 @@ option_list = list(
 opts = optparse::parse_args(optparse::OptionParser(option_list=option_list))
 
 config <- covidcommon::load_config(opts$c)
-if (is.na(config)) {
+if (length(config) == 0) {
   stop("no configuration found -- please set CONFIG_PATH environment variable or use the -c command flag")
 }
 

--- a/R/scripts/hosp_run.R
+++ b/R/scripts/hosp_run.R
@@ -21,7 +21,7 @@ option_list = list(
 opt = optparse::parse_args(optparse::OptionParser(option_list=option_list))
 
 config <- covidcommon::load_config(opt$c)
-if (is.na(config)) {
+if (length(config) == 0) {
   stop("no configuration found -- please set CONFIG_PATH environment variable or use the -c command flag")
 }
 

--- a/R/scripts/hosp_run_geoid.R
+++ b/R/scripts/hosp_run_geoid.R
@@ -20,7 +20,7 @@ option_list = list(
 opt = optparse::parse_args(optparse::OptionParser(option_list=option_list))
 
 config <- covidcommon::load_config(opt$c)
-if (is.na(config)) {
+if (length(config) == 0) {
   stop("no configuration found -- please set CONFIG_PATH environment variable or use the -c command flag")
 }
 

--- a/R/scripts/hosp_run_geoid_fixedIFR.R
+++ b/R/scripts/hosp_run_geoid_fixedIFR.R
@@ -20,7 +20,7 @@ option_list = list(
 opt = optparse::parse_args(optparse::OptionParser(option_list=option_list))
 
 config <- covidcommon::load_config(opt$c)
-if (is.na(config)) {
+if (length(config) == 0) {
   stop("no configuration found -- please set CONFIG_PATH environment variable or use the -c command flag")
 }
 


### PR DESCRIPTION
We want to check `length(config) == 0` instead of `is.na(config)`.