### PR TITLE
Fix load-bearing typo

### DIFF
--- a/R/scripts/hosp_run.R
+++ b/R/scripts/hosp_run.R
@@ -184,7 +184,7 @@ if(run_age_adjust){
                                                      time_ICUdur_pars = time_ICUdur_pars,
                                                      cores = ncore,
                                                      data_dir = data_dir,
-                                                     dscenario_name = paste(cmd0,"death",sep="_"),
+                                                     dscenario_name = cmd0,
                                                      use_parquet = TRUE
       )
     }

--- a/R/scripts/hosp_run.R
+++ b/R/scripts/hosp_run.R
@@ -184,7 +184,7 @@ if(run_age_adjust){
                                                      time_ICUdur_pars = time_ICUdur_pars,
                                                      cores = ncore,
                                                      data_dir = data_dir,
-                                                     dscenario_name = paste(cmd,"death",sep="_"),
+                                                     dscenario_name = paste(cmd0,"death",sep="_"),
                                                      use_parquet = TRUE
       )
     }


### PR DESCRIPTION
Should be referencing `cmd0` here (a single-valued character vector) instead of `cmd` (a multi-valued character vector) to prevent an obscure error later in `write_hosp_output` when we go to write the output file.