### PR TITLE
Add env var for writing non-overlapping blocks of sim file outputs in AWS Batch

### DIFF
--- a/R/pkgs/hospitalization/R/hospdeath.R
+++ b/R/pkgs/hospitalization/R/hospdeath.R
@@ -250,8 +250,10 @@ build_hospdeath_par <- function(p_hosp,
   print(paste("Running over",n_sim,"simulations"))
 
   pkgs <- c("dplyr", "readr", "data.table", "tidyr", "hospitalization")
+  sim_block <- as.integer(Sys.getenv("AWS_BATCH_SIM_BLOCK", unset="0"))
   foreach::foreach(s=seq_len(n_sim), .packages=pkgs) %dopar% {
-    dat_ <- hosp_load_scenario_sim(data_dir,s,
+    sim_id <- s + sim_block
+    dat_ <- hosp_load_scenario_sim(data_dir,sim_id,
                                    keep_compartments = "diffI",
                                    geoid_len = 5,
                                    use_parquet = use_parquet) %>%
@@ -310,7 +312,7 @@ build_hospdeath_par <- function(p_hosp,
              icu_curr = 0,
              hosp_curr = 0)) %>%
       arrange(date_inds, geo_ind)
-    write_hosp_output(root_out_dir, data_dir, dscenario_name, s, res, use_parquet)
+    write_hosp_output(root_out_dir, data_dir, dscenario_name, sim_id, res, use_parquet)
     NULL
   }
   doParallel::stopImplicitCluster()
@@ -369,11 +371,13 @@ build_hospdeath_geoid_fixedIFR_par <- function(
   print(paste("Running over",n_sim,"simulations"))
 
   pkgs <- c("dplyr", "readr", "data.table", "tidyr", "hospitalization")
+  sim_block <- as.integer(Sys.getenv("AWS_BATCH_SIM_BLOCK", unset="0"))
   foreach::foreach(s=seq_len(n_sim), .packages=pkgs) %dopar% {
-    dat_I <- hosp_load_scenario_sim(data_dir,s,
-                                   keep_compartments = "diffI",
-                                   geoid_len=5,
-                                   use_parquet = use_parquet) %>%
+    sim_id <- s + sim_block
+    dat_I <- hosp_load_scenario_sim(data_dir, sim_id,
+                                    keep_compartments = "diffI",
+                                    geoid_len=5,
+                                    use_parquet = use_parquet) %>%
       mutate(hosp_curr = 0,
              icu_curr = 0,
              vent_curr = 0,
@@ -441,7 +445,7 @@ build_hospdeath_geoid_fixedIFR_par <- function(
              hosp_curr = 0)) %>%
       arrange(date_inds, geo_ind)
 
-    write_hosp_output(root_out_dir, data_dir, dscenario_name, s, res, use_parquet)
+    write_hosp_output(root_out_dir, data_dir, dscenario_name, sim_id, res, use_parquet)
     NULL
   }
   doParallel::stopImplicitCluster()

--- a/SEIR/seir.py
+++ b/SEIR/seir.py
@@ -21,7 +21,8 @@ S, E, I1, I2, I3, R, cumI = np.arange(ncomp)
 def onerun_SEIR(sim_id, s):
     scipy.random.seed()
 
-    sim_id_str = str(sim_id).zfill(9)
+    sim_block = int(os.environ.get('AWS_BATCH_SIM_BLOCK', 0))
+    sim_id_str = str(sim_block + sim_id).zfill(9)
 
     npi = NPI.NPIBase.execute(npi_config=s.npi_config, global_config=config, geoids=s.spatset.nodenames)
     npi = npi.get().T
@@ -65,7 +66,7 @@ def onerun_SEIR(sim_id, s):
         out_df['comp'].replace(cumI, 'cumI', inplace=True)
         out_df['comp'].replace(ncomp, 'diffI', inplace=True)
         if s.write_csv:
-            npi.to_csv(f"{s.paramdir}{sim_id}.snpi.csv", index_label="time")
+            npi.to_csv(f"{s.paramdir}{sim_id_str}.snpi.csv", index_label="time")
             setup.parameters_write(parameters, f"{s.paramdir}{sim_id_str}.spar","csv")
             out_df.to_csv(
                 f"{s.datadir}{sim_id}.seir.csv",


### PR DESCRIPTION
This way each job will write out a non-overlapping set of files, so there won't be a collision when we write them to the output paths for the job.