### PR TITLE
error handling logic for inference runs

### DIFF
--- a/batch/inference_runner.sh
+++ b/batch/inference_runner.sh
@@ -50,7 +50,7 @@ fi
 
 error_handler() {
 	msg=$1
-	if [ $AWS_BATCH_JOB_ATTEMPT -eq 3]; then
+	if [ $AWS_BATCH_JOB_ATTEMPT -eq 3 ]; then
 		echo $JOB_NAME >> errorfile
 		echo $msg >> errorfile
 		aws s3 cp errorfile $S3_RESULTS_PATH/failures/$AWS_BATCH_JOB_ARRAY_INDEX

--- a/batch/inference_runner.sh
+++ b/batch/inference_runner.sh
@@ -9,6 +9,13 @@ set -x
 # JOB_NAME the name of the job
 # S3_RESULTS_PATH location in S3 to store the results
 
+# Check to see if we should bail on this run because of accumulated errors in other runs
+failure_count=$(aws s3 ls $S3_RESULTS_PATH/failures/ | wc -l)
+if [ $failure_count -gt 10 ]; then
+	echo "Failing run because number of child job failurs is $failure_count"
+	exit 1
+fi
+
 # setup the python environment
 HOME=/home/app
 PYENV_ROOT=$HOME/.pyenv
@@ -41,14 +48,26 @@ if [ -n "$S3_LAST_JOB_OUTPUT" ]; then
 	done
 fi
 
+error_handler() {
+	msg=$1
+	if [ $AWS_BATCH_JOB_ATTEMPT -eq 3]; then
+		echo $JOB_NAME >> errorfile
+		echo $msg >> errorfile
+		aws s3 cp errorfile $S3_RESULTS_PATH/failures/$AWS_BATCH_JOB_ARRAY_INDEX
+		exit 0
+	else
+		echo $1
+		exit 1
+	fi
+}
+
 # Pick up stuff that changed
 # TODO(jwills): maybe move this to like a prep script?
 Rscript COVIDScenarioPipeline/local_install.R
 local_install_ret=$?
 
 if [ $local_install_ret -ne 0 ]; then
-	echo "Error code returned from running local_install.R: $local_install_ret"
-	exit 1
+	error_handler "Error code returned from running local_install.R: $local_install_ret"
 fi
 
 
@@ -56,8 +75,7 @@ fi
 python_install_ret=$?
 
 if [ $python_install_ret -ne 0 ]; then
-	echo "Error code returned from running `python setup.py install`: $python_install_ret"
-	exit 1
+	error_handler "Error code returned from running `python setup.py install`: $python_install_ret"
 fi
 
 echo "State of directory before we start"
@@ -80,8 +98,7 @@ Rscript COVIDScenarioPipeline/R/scripts/full_filter.R -p COVIDScenarioPipeline -
 
 dvc_ret=$?
 if [ $dvc_ret -ne 0 ]; then
-        echo "Error code returned from full_filter.R: $dvc_ret"
-	exit 1
+        error_handler "Error code returned from full_filter.R: $dvc_ret"
 fi
 
 for output in "${DVC_OUTPUTS_ARRAY[@]}"

--- a/batch/inference_runner.sh
+++ b/batch/inference_runner.sh
@@ -12,7 +12,7 @@ set -x
 # Check to see if we should bail on this run because of accumulated errors in other runs
 failure_count=$(aws s3 ls $S3_RESULTS_PATH/failures/ | wc -l)
 if [ $failure_count -gt 10 ]; then
-	echo "Failing run because number of child job failurs is $failure_count"
+	echo "Failing run because total number of previous child job failures is $failure_count"
 	exit 1
 fi
 

--- a/batch/inference_runner.sh
+++ b/batch/inference_runner.sh
@@ -56,7 +56,7 @@ error_handler() {
 		aws s3 cp errorfile $S3_RESULTS_PATH/failures/$AWS_BATCH_JOB_ARRAY_INDEX
 		exit 0
 	else
-		echo $1
+		echo $msg
 		exit 1
 	fi
 }


### PR DESCRIPTION
We currently have the problem where a single failure in one of the child jobs will cause the parent job for a run to be marked as failed, which prevents the copy job from running during the last phase of the pipeline. A small number of child job failures isn't actually a problem for us, so I'm adding a handler function that will:

1) Trigger a retry of the job on a failure when the retry count is less than 3,
2) Exit the job on its third failure as "successful," but writing a failure indicator file to S3 marking the job as having had a failure.

To prevent the problem where *every* job we run fails but gets marked as succeeding, I'm adding a check to the start of each inference run that will count up the number of failure indicator files in the failure indicator directory, and if it is greater than 10, every job in the run will fail.

Note that a consequence of this change is that some inference runs will re-start from scratch again after an initial failure, which will mean that some slots will have been generated using fewer sims than other slots. I'm not sure of the right way to handle this, but I'm assuming that dropping that slot entirely is an acceptable fallback.