### PR TITLE
add option to choose USAF or CSSE for groundtruth

### DIFF
--- a/R/pkgs/covidcommon/DESCRIPTION
+++ b/R/pkgs/covidcommon/DESCRIPTION
@@ -15,4 +15,4 @@ License: What license it uses
 Encoding: UTF-8
 Suggests: 
     testthat (>= 2.1.0)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1

--- a/R/pkgs/covidcommon/R/DataUtils.R
+++ b/R/pkgs/covidcommon/R/DataUtils.R
@@ -716,7 +716,7 @@ get_groundtruth_from_source <- function(source = "csse", scale = "US county", va
 
   } else if(source == "usafacts" & scale == "US county"){
 
-    rc <- get_USAFacts_data(incl_unassigned = incl_unass) 
+    rc <- get_USAFacts_data(tempfile(), tempfile(), incl_unassigned = incl_unass) 
     rc <- dplyr::select(rc, Update, FIPS, source, !!variables)
     rc <- tidyr::drop_na(rc, tidyselect::everything())
 
@@ -731,7 +731,7 @@ get_groundtruth_from_source <- function(source = "csse", scale = "US county", va
 
   } else if(source == "csse" & scale == "US county"){
 
-    rc <- get_CSSE_US_data(incl_unassigned = incl_unass)
+    rc <- get_CSSE_US_data(tempfile(),tempfile(), incl_unassigned = incl_unass)
     rc <- dplyr::select(rc, Update, FIPS, source, !!variables) 
     rc <- tidyr::drop_na(rc, tidyselect::everything())
 

--- a/R/pkgs/inference/DESCRIPTION
+++ b/R/pkgs/inference/DESCRIPTION
@@ -22,6 +22,6 @@ Imports:
   reticulate,
   truncnorm,
   arrow
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Suggests: 
     testthat

--- a/R/pkgs/inference/R/groundtruth.R
+++ b/R/pkgs/inference/R/groundtruth.R
@@ -49,7 +49,7 @@ get_ground_truth_file <- function(data_path, cache = TRUE, gt_source = "csse") {
 #'
 #' @export
 get_ground_truth <- function(data_path, fips_codes, fips_column_name, start_date, end_date, cache = TRUE, gt_source = "csse"){
-  get_ground_truth_file(data_path,cache,gt_source)
+  get_ground_truth_file(data_path = data_path, cache = cache, gt_source = gt_source)
 
   rc <- suppressMessages(readr::read_csv(data_path,col_types = list(FIPS = readr::col_character())))
   rc <- dplyr::filter(

--- a/R/pkgs/inference/R/groundtruth.R
+++ b/R/pkgs/inference/R/groundtruth.R
@@ -1,17 +1,19 @@
 #' Function to load US COVID data from JHUCSSE
 #' @param data_path Path where to write the data
+#' @param cache logical indicating whether to cache the data (default = TRUE)
+#' @param gt_source string indicating source of ground truth data. options include "csse" or "usafacts" (default csse) 
 #'
 #' @return NULL
 #'
 #' @export
-get_ground_truth_file <- function(data_path, cache = TRUE) {
+get_ground_truth_file <- function(data_path, cache = TRUE, gt_source = "csse") {
   data_dir <- dirname(data_path)
   if(!dir.exists(data_dir)){
     suppressWarnings(dir.create(data_dir,recursive=TRUE))
   }
   if(!(file.exists(data_path) & cache)){
-    message("*** Loading Data from USAFacts\n")
-    cases_deaths <- suppressMessages(covidcommon::get_USAFacts_data(tempfile(),tempfile()))
+    message(paste("*** Loading Data from", gt_source, "\n"))
+    cases_deaths <- suppressMessages(covidcommon::get_groundtruth_from_source(source = gt_source, scale = "US county", variables = c("Confirmed", "Deaths", "incidI", "incidDeath"), incl_unass = FALSE))
     cases_deaths  <- dplyr::arrange(
       dplyr::rename(
         dplyr::mutate(
@@ -46,8 +48,8 @@ get_ground_truth_file <- function(data_path, cache = TRUE) {
 #' @param data_path Path where to write the data
 #'
 #' @export
-get_ground_truth <- function(data_path, fips_codes, fips_column_name, start_date, end_date, cache = TRUE){
-  get_ground_truth_file(data_path,cache)
+get_ground_truth <- function(data_path, fips_codes, fips_column_name, start_date, end_date, cache = TRUE, gt_source = "csse"){
+  get_ground_truth_file(data_path,cache,gt_source)
 
   rc <- suppressMessages(readr::read_csv(data_path,col_types = list(FIPS = readr::col_character())))
   rc <- dplyr::filter(

--- a/R/scripts/create_seeding.R
+++ b/R/scripts/create_seeding.R
@@ -52,9 +52,16 @@ if (length(config) == 0) {
   stop("no configuration found -- please set CONFIG_PATH environment variable or use the -c command flag")
 }
 
-cases_deaths <- covidcommon::get_USAFacts_data()
+## backwards compatibility with configs that don't have filtering$gt_source parameter will use the previous default data source (USA Facts)
+if(is.null(config$filtering$gt_source)){
+  gt_source <- "usafacts"
+} else{
+  gt_source <- config$filtering$gt_source
+}
 
-print("Successfully pulled USAFacts data for seeding.")
+cases_deaths <- covidcommon::get_groundtruth_from_source(source = gt_source, scale = "US county")
+
+print(paste("Successfully pulled", gt_source, "data for seeding."))
 
 all_times <- lubridate::ymd(config$start_date) +
   seq_len(lubridate::ymd(config$end_date) - lubridate::ymd(config$start_date))

--- a/R/scripts/filter_MC.R
+++ b/R/scripts/filter_MC.R
@@ -114,7 +114,14 @@ if("priors"%in%names(config$filtering)) {
 
 ## Runner Script---------------------------------------------------------------------
 
-obs <- inference::get_ground_truth(data_path,geodata[[obs_nodename]],obs_nodename, config$start_date, config$end_date)
+## backwards compatibility with configs that don't have filtering$gt_source parameter will use the previous default data source (USA Facts)
+if(is.null(config$filtering$gt_source)){
+  gt_source <- "usafacts"
+} else{
+  gt_source <- config$filtering$gt_source
+}
+
+obs <- inference::get_ground_truth(data_path,geodata[[obs_nodename]],obs_nodename, config$start_date, config$end_date, TRUE, gt_source)
 
 geonames <- unique(obs[[obs_nodename]])
 

--- a/R/scripts/filter_MC.R
+++ b/R/scripts/filter_MC.R
@@ -121,7 +121,14 @@ if(is.null(config$filtering$gt_source)){
   gt_source <- config$filtering$gt_source
 }
 
-obs <- inference::get_ground_truth(data_path,geodata[[obs_nodename]],obs_nodename, config$start_date, config$end_date, TRUE, gt_source)
+obs <- inference::get_ground_truth(
+          data_path = data_path, 
+          fips_codes = geodata[[obs_nodename]],
+          fips_column_name = obs_nodename, 
+          start_date = config$start_date, 
+          end_date = config$end_date, 
+          gt_source = gt_source
+        )
 
 geonames <- unique(obs[[obs_nodename]])
 

--- a/SEIR/NPI/Stacked.py
+++ b/SEIR/NPI/Stacked.py
@@ -9,7 +9,7 @@ from .base import NPIBase
 REDUCE_PARAMS = ["alpha", "r0", "gamma", "sigma"]
 
 "Cap on # of reduction metadata entries to store in memory"
-REDUCTION_METADATA_CAP = 325
+REDUCTION_METADATA_CAP = 350
 
 
 class Stacked(NPIBase):


### PR DESCRIPTION
Add option to use "csse" or "usafacts" groundtruth data for inference with the filtering$gt_source parameter in the config file.

Uses covidcommon::get_groundtruth_from_source

The code is backwards compatible with configs that are missing filtering$gt_source and those runs will default to USA Facts