### PR TITLE
allow to set seed from R, using variable rng_seed

### DIFF
--- a/minimal_interface.py
+++ b/minimal_interface.py
@@ -61,6 +61,7 @@ from SEIR import seir, setup, file_paths
 from SEIR.utils import config
 from SEIR.profile import profile_options
 from Outcomes import outcomes
+import numpy as np
 
 config.set_file(config_path)
 
@@ -75,6 +76,12 @@ nsim = 10
 interactive = False
 write_csv = False
 write_parquet = True
+try:
+    rng_seed
+except NameError:
+    rng_seed = None
+
+np.random.seed(rng_seed)
 
 
 


### PR DESCRIPTION
allow to specify a seed from R as:
reticulate::py_run_string(paste0("rng_seed = ", whatever))
if it is not defined then python does it’s usual thing using /dev/urandom or whatever