### PR TITLE
Inference config writer

### DIFF
--- a/R/pkgs/config.writer/R/create_config_data.R
+++ b/R/pkgs/config.writer/R/create_config_data.R
@@ -780,6 +780,7 @@ daily_mean_reduction <- function(dat,
 
     dat <- dat %>%
         dplyr::filter(type == "transmission") %>%
+        dplyr::filter(is.na(parameter) | parameter == "R0") %>%
         dplyr::mutate(mean = dplyr::case_when(value_dist == "truncnorm" ~
                                                   truncnorm::etruncnorm(a=value_a, b=value_b, mean=value_mean, sd=value_sd),
                                               value_dist == "fixed" ~

--- a/R/pkgs/config.writer/R/process_npi_list.R
+++ b/R/pkgs/config.writer/R/process_npi_list.R
@@ -503,8 +503,9 @@ generate_multiple_variants_state <- function(variant_path_1,
                          #, sd_variant = sum(sd_variant)
                          ) %>% # THIS IS NOT THE RIGHT SD BUT DOESN'T MATTER B/C WE DON'T USE IT
         dplyr::ungroup() %>%
-        dplyr::mutate(final_week = dplyr::if_else(start_date >= lubridate::floor_date(projection_start_date-14, "week") & start_date < projection_start_date,
-                                                  1, NA_real_)) %>%
+        dplyr::mutate(final_week = dplyr::case_when(start_date >= lubridate::floor_date(projection_start_date-14, "week") & start_date < projection_start_date ~ 1,
+                                                    start_date >= projection_start_date ~ 0,
+                                                    TRUE ~ NA_real_)) %>%
         dplyr::group_by(location, final_week) %>%
         dplyr::mutate(final_week = cumsum(final_week)) %>%
         dplyr::group_by(R_ratio, location, final_week) %>%


### PR DESCRIPTION
Fix config.writer bug that generates overlapping variant interventions due to incorrect grouping 