### PR TITLE
fix for resume: param_name for NPIs is always taken from config

### DIFF
--- a/SEIR/NPI/MultiTimeReduce.py
+++ b/SEIR/NPI/MultiTimeReduce.py
@@ -165,7 +165,12 @@ class MultiTimeReduce(NPIBase):
         self.parameters = self.parameters.loc[self.affected_geoids]
         # self.parameters = self.parameters[self.parameters.index.isin(self.affected_geoids) ]
         # self.parameters = self.parameters[self.affected_geoids]
-        self.param_name = self.parameters["parameter"].unique()[0]          # [0] to convert ndarray to str
+
+        # parameter name is picked from config too: (before: )
+        #self.param_name = self.parameters["parameter"].unique()[0]  # [0] to convert ndarray to str
+        #now:
+        self.param_name = npi_config["parameter"].as_str().lower().replace(" ", "")
+        self.parameters["parameter"] = self.param_name
 
     def __get_affected_geoids(self, npi_config):
         # Optional config field "affected_geoids"

--- a/SEIR/NPI/Reduce.py
+++ b/SEIR/NPI/Reduce.py
@@ -93,7 +93,7 @@ class Reduce(NPIBase):
         loaded_df.index = loaded_df.geoid
         loaded_df = loaded_df[loaded_df['npi_name'] == self.name]
         self.parameters = loaded_df[['npi_name','start_date','end_date','parameter','reduction']].copy()
-
+        # dates are picked from config
         self.parameters["start_date"] = npi_config["period_start_date"].as_date()  \
             if npi_config["period_start_date"].exists() else self.start_date
         self.parameters["end_date"] = npi_config["period_end_date"].as_date() \
@@ -109,7 +109,11 @@ class Reduce(NPIBase):
         #    self.parameters["start_date"] = self.end_date
 
         self.affected_geoids = set(self.parameters.index)
-        self.param_name = self.parameters["parameter"].unique()[0]  # [0] to convert ndarray to str
+        # parameter name is picked from config too: (before: )
+        #self.param_name = self.parameters["parameter"].unique()[0]  # [0] to convert ndarray to str
+        #now:
+        self.param_name = npi_config["parameter"].as_str().lower().replace(" ", "")
+        self.parameters["parameter"] = self.param_name
 
     def getReduction(self, param, default=0.0):
         "Return the reduction for this param, `default` if no reduction defined"

--- a/SEIR/NPI/ReduceIntervention.py
+++ b/SEIR/NPI/ReduceIntervention.py
@@ -151,7 +151,11 @@ class ReduceIntervention(NPIBase):
         #    self.parameters["start_date"] = self.end_date
 
         self.affected_geoids = set(self.parameters.index)
-        self.param_name = self.parameters["parameter"].unique()[0]  # [0] to convert ndarray to str
+        # parameter name is picked from config too: (before: )
+        #self.param_name = self.parameters["parameter"].unique()[0]  # [0] to convert ndarray to str
+        #now:
+        self.param_name = npi_config["parameter"].as_str().lower().replace(" ", "")
+        self.parameters["parameter"] = self.param_name
 
     def __createFromConfig(self, npi_config):
         # Get name of the parameter to reduce


### PR DESCRIPTION
**Before**, if there is this specific interventions in the parquet dataframe:

1. take the values, the parameter name, and the affected geoids from the dataframe
2. take the dates from the config

**After**, if there is this specific interventions in the parquet dataframe:

1. take the values and the affected geoids from the dataframe
2. take the dates and the parameter name from the config

if no intervention with the same name is the parquet datraframe --> created from scratch from config