### PR TITLE
Hive-partitioning stub, require big inference changes

### DIFF
--- a/R/pkgs/covidcommon/R/file_paths.R
+++ b/R/pkgs/covidcommon/R/file_paths.R
@@ -33,7 +33,7 @@ create_prefix <- function(...,prefix='',sep='-',trailing_separator=""){
 ## Function for creating file names from their components
 ##' @export
 create_file_name <- function(run_id,prefix,index,type,extension='parquet',create_directory = TRUE){
-  rc <- sprintf("model_output/%s/%s%09d.%s.%s.%s",type,prefix,index,run_id,type,extension)
+  rc <- sprintf("model_output/%s/%s/sim_id=%09d/%s.%s.%s",type,prefix,index,run_id,type,extension)
   if(create_directory){
     if(!dir.exists(dirname(rc))){
       dir.create(dirname(rc), recursive = TRUE)

--- a/R/pkgs/covidcommon/R/file_paths.R
+++ b/R/pkgs/covidcommon/R/file_paths.R
@@ -33,7 +33,7 @@ create_prefix <- function(...,prefix='',sep='-',trailing_separator=""){
 ## Function for creating file names from their components
 ##' @export
 create_file_name <- function(run_id,prefix,index,type,extension='parquet',create_directory = TRUE){
-  rc <- sprintf("model_output/%s/%s/sim_id=%09d/%s.%s.%s",type,prefix,index,run_id,type,extension)
+  rc <- sprintf("model_output/%s/%ssim_id=%09d/%s.%s.%s",type,prefix,index,run_id,type,extension)
   if(create_directory){
     if(!dir.exists(dirname(rc))){
       dir.create(dirname(rc), recursive = TRUE)

--- a/R/scripts/filter_MC.R
+++ b/R/scripts/filter_MC.R
@@ -219,11 +219,17 @@ for(scenario in scenarios) {
     ci_prefix <- covidcommon::create_prefix(prefix=slot_prefix,'chimeric','intermediate',sep='/',trailing_separator='/') #] "USA/inference/med/2022.03.04.10:18:42.CET/chimeric/intermediate/"
     gi_prefix <- covidcommon::create_prefix(prefix=slot_prefix,'global','intermediate',sep='/',trailing_separator='/')  # USA/inference/med/2022.03.04.10:21:44.CET/global/intermediate/"
 
-    chimeric_block_prefix <- covidcommon::create_prefix(prefix=ci_prefix, slot=list(opt$this_slot,"%09d"), sep='.', trailing_separator='.')  # "USA/inference/med/2022.03.04.10:18:42.CET/chimeric/intermediate/000000001."
-    chimeric_local_prefix <- covidcommon::create_prefix(prefix=chimeric_block_prefix, slot=list(opt$this_block,"%09d"), sep='.', trailing_separator='.') # "USA/inference/med/2022.03.04.10:18:42.CET/chimeric/intermediate/000000001.000000001."
+    chimeric_block_prefix <- covidcommon::create_prefix(prefix=ci_prefix, slot=list(opt$this_slot,"slot=%09d"), sep='/', trailing_separator='/')
+    #chimeric_block_prefix <- covidcommon::create_prefix(prefix=chimeric_block_prefix_temp, slot=list(opt$this_slot,"%09d"), sep='.', trailing_separator='.')  # "USA/inference/med/2022.03.04.10:18:42.CET/chimeric/intermediate/000000001."
+    
+    chimeric_local_prefix <- covidcommon::create_prefix(prefix=chimeric_block_prefix, slot=list(opt$this_block,"block=%09d"), sep='/', trailing_separator='/') # "USA/inference/med/2022.03.04.10:18:42.CET/chimeric/intermediate/000000001.000000001."
+    #chimeric_local_prefix <- covidcommon::create_prefix(prefix=chimeric_local_prefix_temp, slot=list(opt$this_block,"%09d"), sep='.', trailing_separator='.') # "USA/inference/med/2022.03.04.10:18:42.CET/chimeric/intermediate/000000001.000000001."
 
-    global_block_prefix <- covidcommon::create_prefix(prefix=gi_prefix, slot=list(opt$this_slot,"%09d"), sep='.', trailing_separator='.') #  "USA/inference/med/2022.03.04.10:18:42.CET/global/intermediate/000000001."
-    global_local_prefix <- covidcommon::create_prefix(prefix=global_block_prefix, slot=list(opt$this_block,"%09d"), sep='.', trailing_separator='.') # "USA/inference/med/2022.03.04.10:18:42.CET/global/intermediate/000000001.000000001."
+    global_block_prefix <- covidcommon::create_prefix(prefix=gi_prefix, slot=list(opt$this_slot,"slot=%09d"), sep='/', trailing_separator='/')
+    #global_block_prefix <- covidcommon::create_prefix(prefix=global_block_prefix_temp, slot=list(opt$this_slot,"%09d"), sep='.', trailing_separator='.') #  "USA/inference/med/2022.03.04.10:18:42.CET/global/intermediate/000000001."
+    
+    global_local_prefix <- covidcommon::create_prefix(prefix=global_block_prefix, slot=list(opt$this_block,"block=%09d"), sep='/', trailing_separator='/')
+    #global_local_prefix <- covidcommon::create_prefix(prefix=global_local_prefix_temp, slot=list(opt$this_block,"%09d"), sep='.', trailing_separator='.') # "USA/inference/med/2022.03.04.10:18:42.CET/global/intermediate/000000001.000000001."
 
     ## python configuration: build simulator model initialized with compartment and all.
     gempyor_inference_runner <- gempyor$InferenceSimulator(

--- a/gempyor_pkg/src/gempyor/file_paths.py
+++ b/gempyor_pkg/src/gempyor/file_paths.py
@@ -17,7 +17,7 @@ def create_file_name_without_extension(
 ):
     if create_directory:
         os.makedirs(create_dir_name(run_id, prefix, ftype), exist_ok=True)
-    return "model_output/%s/%s/sim_id=%09d/%s.%s" % (ftype, prefix, index, run_id, ftype)
+    return "model_output/%s/%ssim_id=%09d/%s.%s" % (ftype, prefix, index, run_id, ftype)
 
 
 def run_id():

--- a/gempyor_pkg/src/gempyor/file_paths.py
+++ b/gempyor_pkg/src/gempyor/file_paths.py
@@ -17,7 +17,7 @@ def create_file_name_without_extension(
 ):
     if create_directory:
         os.makedirs(create_dir_name(run_id, prefix, ftype), exist_ok=True)
-    return "model_output/%s/%s%09d.%s.%s" % (ftype, prefix, index, run_id, ftype)
+    return "model_output/%s/%s/sim_id=%09d/%s.%s" % (ftype, prefix, index, run_id, ftype)
 
 
 def run_id():


### PR DESCRIPTION
We have to discuss this. The code uses a mix of slot and block very weirdly

```r
    slot_prefix <- covidcommon::create_prefix(config$name,scenario,deathrate,opt$run_id,sep='/',trailing_separator='/')  # "USA/inference/med/2022.03.04.10:18:42.CET/"

    gf_prefix <- covidcommon::create_prefix(prefix=slot_prefix,'global','final',sep='/',trailing_separator='/')  # "USA/inference/med/2022.03.04.10:18:42.CET/global/final/"
    ci_prefix <- covidcommon::create_prefix(prefix=slot_prefix,'chimeric','intermediate',sep='/',trailing_separator='/') #] "USA/inference/med/2022.03.04.10:18:42.CET/chimeric/intermediate/"
    gi_prefix <- covidcommon::create_prefix(prefix=slot_prefix,'global','intermediate',sep='/',trailing_separator='/')  # USA/inference/med/2022.03.04.10:21:44.CET/global/intermediate/"

    chimeric_block_prefix <- covidcommon::create_prefix(prefix=ci_prefix, slot=list(opt$this_slot,"%09d"), sep='.', trailing_separator='.')  # "USA/inference/med/2022.03.04.10:18:42.CET/chimeric/intermediate/000000001."
    chimeric_local_prefix <- covidcommon::create_prefix(prefix=chimeric_block_prefix, slot=list(opt$this_block,"%09d"), sep='.', trailing_separator='.') # "USA/inference/med/2022.03.04.10:18:42.CET/chimeric/intermediate/000000001.000000001."

    global_block_prefix <- covidcommon::create_prefix(prefix=gi_prefix, slot=list(opt$this_slot,"%09d"), sep='.', trailing_separator='.') #  "USA/inference/med/2022.03.04.10:18:42.CET/global/intermediate/000000001."
    global_local_prefix <- covidcommon::create_prefix(prefix=global_block_prefix, slot=list(opt$this_block,"%09d"), sep='.', trailing_separator='.') # "USA/inference/med/2022.03.04.10:18:42.CET/global/intermediate/000000001.000000001."

```